### PR TITLE
Parviz bugfix

### DIFF
--- a/inventory.cfg
+++ b/inventory.cfg
@@ -1,11 +1,11 @@
-[all]
+[control]               # <-- new group name
 ctrl ansible_host=192.168.56.100
+
+[workers]               # <-- another clearer group name
 node-1 ansible_host=192.168.56.101
 node-2 ansible_host=192.168.56.102
 
-[ctrl]
-ctrl ansible_host=192.168.56.100
+[all:children]          # optional – lets you target every VM with “hosts: all”
+control
+workers
 
-[nodes]
-node-1 ansible_host=192.168.56.101
-node-2 ansible_host=192.168.56.102

--- a/inventory.cfg
+++ b/inventory.cfg
@@ -1,11 +1,11 @@
-[control]               # <-- new group name
+[all]
 ctrl ansible_host=192.168.56.100
-
-[workers]               # <-- another clearer group name
 node-1 ansible_host=192.168.56.101
 node-2 ansible_host=192.168.56.102
 
-[all:children]          # optional – lets you target every VM with “hosts: all”
-control
-workers
+[ctrl]
+ctrl ansible_host=192.168.56.100
 
+[nodes]
+node-1 ansible_host=192.168.56.101
+node-2 ansible_host=192.168.56.102

--- a/playbooks/ctrl.yaml
+++ b/playbooks/ctrl.yaml
@@ -1,3 +1,16 @@
+---
+
+- name: Wait until every node is reachable on its static IP
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: wait for SSH to answer
+      wait_for_connection:
+        delay: 5         # seconds to wait before first try
+        timeout: 180     # abort after 3 minutes
+
+
+
 - import_playbook: general.yaml
 - hosts: ctrl
   become: yes

--- a/playbooks/node.yaml
+++ b/playbooks/node.yaml
@@ -1,24 +1,6 @@
 - import_playbook: general.yaml
-
 - hosts: nodes
   become: yes
   tasks:
-    - name: Get kubeadm join command from controller
-      shell: kubeadm token create --print-join-command
-      delegate_to: ctrl         
-      register: join_command
-      changed_when: false
-
-    - name: Check whether this node is already part of the cluster
-      stat:
-        path: /etc/kubernetes/kubelet.conf   =
-      register: kubelet_conf
-
-    - name: Join the Kubernetes cluster
-      shell: >
-        {{ join_command.stdout }}                      
-        --cri-socket unix:///run/containerd/containerd.sock 
-      args:
-        warn: false
-      when: not kubelet_conf.stat.exists    # idempotent: run only once
-
+    - name: Node-specific setup
+      debug: msg="Running node-specific tasks"


### PR DESCRIPTION
Most important change is in vagrantFile, that should fix the 'protocol' bug. 

    ctrl.vm.provision "shell", run: "once", inline: <<-SHELL
      echo "Pinging host-only gateway to wake the link…"
      ping -c1 192.168.56.1 || true
    SHELL
 

Rest are work in proggress, but there should not be any error when running vagrant up in the current state.