### PR TITLE
Fix metamorphic testing spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The table summarizes the implemented tests.
 | **Model Development**       | - Model predicts correct output shape for multiple inputs                   |
 | **ML Infrastructure**       | - Required model files exist (`BoW`, classifier)                             |
 | **Monitoring**              | - Predictions are within valid range `{0, 1}`                                |
-| **Mutamorphic Testing**     | - Synonyms and paraphrases produce consistent predictions                   |
+| **Metamorphic Testing**     | - Synonyms and paraphrases produce consistent predictions                   |
 | **Non-functional Requirements** | - Model inference takes < 0.5 seconds per input                        |
 
 Continuous Training part has not been implemented yet. Tests can be run with pytest `tests/test_main.py` inside the `model-training` repository. 


### PR DESCRIPTION
## Summary
- fix spelling in README table

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684155721ee48327b932f6cf9f7ff786